### PR TITLE
General bugs fixex

### DIFF
--- a/R/calibration_glmnetmx.R
+++ b/R/calibration_glmnetmx.R
@@ -1,27 +1,31 @@
 #Looping through candidate models using cores
 calibration_glmnetmx <- function(data, #Data in **CLASS??** format
-          #pr_bg, #Column name with presence (1) or background (0)
-          formula_grid, #Grid with formulas
-          test_convex = TRUE, #Test convex curves in quadratic models?
-          #folds = 4, #Columns name with k_folds or vector indicating k_folds
-          parallel = TRUE,
-          ncores = 1,
-          progress_bar = TRUE, #Show progress bar? Only works if parallel_type = "doSNOW"
-          write_summary = FALSE, #Write summary of each candidate evaluations?
-          out_dir = NULL, #Name of the folder to write candidate evaluations
-          parallel_type = "doSNOW",
-          return_replicate = TRUE,
-          omrat_thr = c(5, 10),
-          omrat_threshold = 10,
-          skip_existing_models = FALSE, #Only works if write_summary = TRUE
-          verbose = TRUE){
+                                 #pr_bg, #Column name with presence (1) or background (0)
+                                 formula_grid, #Grid with formulas
+                                 test_convex = TRUE, #Test convex curves in quadratic models?
+                                 #folds = 4, #Columns name with k_folds or vector indicating k_folds
+                                 parallel = TRUE,
+                                 ncores = 1,
+                                 progress_bar = TRUE, #Show progress bar? Only works if parallel_type = "doSNOW"
+                                 write_summary = FALSE, #Write summary of each candidate evaluations?
+                                 out_dir = NULL, #Name of the folder to write candidate evaluations
+                                 parallel_type = "doSNOW",
+                                 return_replicate = TRUE,
+                                 omrat_thr = c(5, 10),
+                                 omrat_threshold = 10,
+                                 allow_tolerance = TRUE, #If omission rate is higher than set, select the model with minimum omission rate
+                                 tolerance = 0.01,
+                                 AIC = "ws",
+                                 delta_aic = 2,
+                                 skip_existing_models = FALSE, #Only works if write_summary = TRUE
+                                 verbose = TRUE){
 
   #Args to parallel
   to_export <- c("aic_nk", "aic_ws", "eval_stats","glmnet_mx",
-                "maxnet.default.regularization", "omrat",
-                "predict.glmnet_mx", "empty_replicates",
-                "empty_summary", "hinge", "hingeval", "thresholds",
-                "thresholdval", "categorical", "categoricalval")
+                 "maxnet.default.regularization", "omrat",
+                 "predict.glmnet_mx", "empty_replicates",
+                 "empty_summary", "hinge", "hingeval", "thresholds",
+                 "thresholdval", "categorical", "categoricalval")
 
   #If write_summary = TRUE, create directory
   if(write_summary){
@@ -76,147 +80,147 @@ calibration_glmnetmx <- function(data, #Data in **CLASS??** format
       if (parallel_type == "doSNOW") {
         doSNOW::registerDoSNOW(cl)
         if (isTRUE(progress_bar))
- opts <- list(progress = progress)
+          opts <- list(progress = progress)
         else opts <- NULL
       }
-  #Start results convex
- results_convex <- foreach::foreach(
+      #Start results convex
+      results_convex <- foreach::foreach(
         x = 1:n, .options.snow = opts,
         .export = to_export) %dopar% {
- #Get grid x
- grid_x <- q_grids[x,] #Get i candidate model
- formula_x <- as.formula(grid_x$Formulas) #Get formula from grid x
- reg_x <- grid_x$regm #Get regularization multiplier from grid x
+          #Get grid x
+          grid_x <- q_grids[x,] #Get i candidate model
+          formula_x <- as.formula(grid_x$Formulas) #Get formula from grid x
+          reg_x <- grid_x$regm #Get regularization multiplier from grid x
 
- #Complete model with AIC
- m_aic <- try(glmnet_mx(p = data$calibration_data$pr_bg,
-                        data = data$calibration_data,
-           f = formula_x, regmult = reg_x, calculate_AIC = T),
-     silent = TRUE)
- if(any(class(m_aic) == "try-error")) {
-      npar <- NA
-      AICc <- NA
-      is_c <- NA
-      mods <- NA
-      class(mods) <- "try-error"
-      } else {
+          #Complete model with AIC
+          m_aic <- try(glmnet_mx(p = data$calibration_data$pr_bg,
+                                 data = data$calibration_data,
+                                 f = formula_x, regmult = reg_x, calculate_AIC = T),
+                       silent = TRUE)
+          if(any(class(m_aic) == "try-error")) {
+            npar <- NA
+            AICc <- NA
+            is_c <- NA
+            mods <- NA
+            class(mods) <- "try-error"
+          } else {
 
- #Get number of parameters
- npar <- length(m_aic$betas)
+            #Get number of parameters
+            npar <- length(m_aic$betas)
 
- #Calculate AIC from Warren
- vals <- predict.glmnet_mx(m_aic,
-                           data$calibration_data[data$calibration_data$pr_bg == 1,],
-                           type = "exponential")
+            #Calculate AIC from Warren
+            vals <- predict.glmnet_mx(m_aic,
+                                      data$calibration_data[data$calibration_data$pr_bg == 1,],
+                                      type = "exponential")
 
- AICc <- aic_ws(pred_occs = vals, ncoefs = npar)
-
-
- #Check if model has convex curves
- m_betas <- m_aic$betas
- # #Check plot
- # p_aic <- predict.glmnet_mx(m_aic, data, type = "cloglog")
- # plot_aic <- cbind(data, pred = p_aic)
- # plot_aic[,c(5,14)] %>% plot()
-
- #Select only quadratic betas
- q_betas <- m_betas[grepl("\\^2", names(m_betas))]
- #Check if is convex
- if(length(q_betas) == 0) {
-   is_c <- FALSE} else {
-     is_c <- any(q_betas > 0)
-   }
-      }
-
- #If is convex, write results and check another combination
- if(isTRUE(is_c) | is.na(is_c)){
-   ####Save metrics in a dataframe
-   all_reg <- unique(formula_grid$regm)
-   grid_q <- do.call("rbind",
-         lapply(seq_along(all_reg), function(k){
-         grid_x_i <- grid_x
-         grid_x_i$regm <- all_reg[k]
-         #Check id
-         grid_x_i$ID<- formula_grid[formula_grid$Formulas ==
-                                      grid_x$Formulas &
-                                      formula_grid$regm == all_reg[k], "ID"]
-        return(grid_x_i)
-  }))
-
-   df_eval_q <- empty_replicates(omrat_thr = omrat_thr,
-    n_row = nrow(grid_q)*length(data$kfolds),
-    replicates = names(data$kfolds), is_c = is_c)
-
-   df_eval_q2 <- cbind(grid_q, df_eval_q)
-
-   #Summarize results
-   eval_final_q <- empty_summary(omrat_thr = omrat_thr,
-      is_c = is_c)
-   eval_final_q <- cbind(grid_q, eval_final_q)
-
- } else {#If is not convex, keep calculating metrics
-   bgind <- which(data$calibration_data == 0)
-   mods <- lapply(1:length(data$kfolds), function(i) {
-     notrain <- -data$kfolds[[i]]
-     data_i <- data$calibration_data[notrain,]
-    #Run model
-     mod_i <- glmnet_mx(p = data_i$pr_bg, data = data_i,
-     f = formula_x, regmult = reg_x,
-     calculate_AIC = FALSE)
-
-     #Predict model only to background
-     pred_i <- as.numeric(predict(object = mod_i,
-                                  newdata = data$calibration_data,
-                                  clamp = FALSE, type = "cloglog"))
-
-     #Extract suitability in train and test points
-     suit_val_cal <- pred_i[unique(c(notrain, -bgind))]
-     suit_val_eval <- pred_i[which(!-notrain %in% bgind)]
-
-     ####Calculate omission rate following kuenm####
-     om_rate <- omrat(threshold = omrat_thr,
-         pred_train = suit_val_cal,
-         pred_test = suit_val_eval)
-     #Calculate pROC following enmpa
-     proc_i <- enmpa::proc_enm(test_prediction = suit_val_eval,
-  prediction = pred_i)
+            AICc <- aic_ws(pred_occs = vals, ncoefs = npar)
 
 
-    ####Save metrics in a dataframe
-     df_eval_q <- data.frame(Replicate = i,
-         t(data.frame(om_rate)),
-         proc_auc_ratio = proc_i$pROC_summary[1],
-         proc_pval = proc_i$pROC_summary[2],
-         AIC_nk = m_aic$AIC,
-         AIC_ws = AICc,
-         npar = npar,
-         is_convex = is_c,
-         row.names = NULL)
-     df_eval_q2 <- cbind(grid_x, df_eval_q)
-     return(df_eval_q2)
-   })
-   names(mods) <- names(data$kfolds)
-   #Return evaluation final
-   eval_final_q <- do.call("rbind", mods)
+            #Check if model has convex curves
+            m_betas <- m_aic$betas
+            # #Check plot
+            # p_aic <- predict.glmnet_mx(m_aic, data, type = "cloglog")
+            # plot_aic <- cbind(data, pred = p_aic)
+            # plot_aic[,c(5,14)] %>% plot()
 
-   #Summarize results?
-   eval_final_q_summary <- eval_stats(eval_final_q)
+            #Select only quadratic betas
+            q_betas <- m_betas[grepl("\\^2", names(m_betas))]
+            #Check if is convex
+            if(length(q_betas) == 0) {
+              is_c <- FALSE} else {
+                is_c <- any(q_betas > 0)
+              }
+          }
 
- } #End of else
+          #If is convex, write results and check another combination
+          if(isTRUE(is_c) | is.na(is_c)){
+            ####Save metrics in a dataframe
+            all_reg <- unique(formula_grid$regm)
+            grid_q <- do.call("rbind",
+                              lapply(seq_along(all_reg), function(k){
+                                grid_x_i <- grid_x
+                                grid_x_i$regm <- all_reg[k]
+                                #Check id
+                                grid_x_i$ID<- formula_grid[formula_grid$Formulas ==
+                                                             grid_x$Formulas &
+                                                             formula_grid$regm == all_reg[k], "ID"]
+                                return(grid_x_i)
+                              }))
 
- #If write_summary = T...
- if(write_summary){
-   write.csv(eval_final_q_summary, file.path(out_dir,
-        paste0("Summary_cand_model_", grid_x$ID, ".csv")),
-    row.names = F)
- }
+            df_eval_q <- empty_replicates(omrat_thr = omrat_thr,
+                                          n_row = nrow(grid_q)*length(data$kfolds),
+                                          replicates = names(data$kfolds), is_c = is_c)
 
- #Return replicates?
- if(!return_replicate)
-   eval_final_q <- NULL
+            df_eval_q2 <- cbind(grid_q, df_eval_q)
 
- return(list(All_results = eval_final_q,
-             Summary = eval_final_q_summary))
+            #Summarize results
+            eval_final_q <- empty_summary(omrat_thr = omrat_thr,
+                                          is_c = is_c)
+            eval_final_q_summary <- cbind(grid_q, eval_final_q)
+
+          } else {#If is not convex, keep calculating metrics
+            bgind <- which(data$calibration_data == 0)
+            mods <- lapply(1:length(data$kfolds), function(i) {
+              notrain <- -data$kfolds[[i]]
+              data_i <- data$calibration_data[notrain,]
+              #Run model
+              mod_i <- glmnet_mx(p = data_i$pr_bg, data = data_i,
+                                 f = formula_x, regmult = reg_x,
+                                 calculate_AIC = FALSE)
+
+              #Predict model only to background
+              pred_i <- as.numeric(predict(object = mod_i,
+                                           newdata = data$calibration_data,
+                                           clamp = FALSE, type = "cloglog"))
+
+              #Extract suitability in train and test points
+              suit_val_cal <- pred_i[unique(c(notrain, -bgind))]
+              suit_val_eval <- pred_i[which(!-notrain %in% bgind)]
+
+              ####Calculate omission rate following kuenm####
+              om_rate <- omrat(threshold = omrat_thr,
+                               pred_train = suit_val_cal,
+                               pred_test = suit_val_eval)
+              #Calculate pROC following enmpa
+              proc_i <- enmpa::proc_enm(test_prediction = suit_val_eval,
+                                        prediction = pred_i)
+
+
+              ####Save metrics in a dataframe
+              df_eval_q <- data.frame(Replicate = i,
+                                      t(data.frame(om_rate)),
+                                      proc_auc_ratio = proc_i$pROC_summary[1],
+                                      proc_pval = proc_i$pROC_summary[2],
+                                      AIC_nk = m_aic$AIC,
+                                      AIC_ws = AICc,
+                                      npar = npar,
+                                      is_convex = is_c,
+                                      row.names = NULL)
+              df_eval_q2 <- cbind(grid_x, df_eval_q)
+              return(df_eval_q2)
+            })
+            names(mods) <- names(data$kfolds)
+            #Return evaluation final
+            eval_final_q <- do.call("rbind", mods)
+
+            #Summarize results?
+            eval_final_q_summary <- eval_stats(eval_final_q)
+
+          } #End of else
+
+          #If write_summary = T...
+          if(write_summary){
+            write.csv(eval_final_q_summary, file.path(out_dir,
+                                                      paste0("Summary_cand_model_", grid_x$ID, ".csv")),
+                      row.names = F)
+          }
+
+          #Return replicates?
+          if(!return_replicate)
+            eval_final_q <- NULL
+
+          return(list(All_results = eval_final_q,
+                      Summary = eval_final_q_summary))
 
 
         } #End of first foreach
@@ -227,10 +231,10 @@ calibration_glmnetmx <- function(data, #Data in **CLASS??** format
   if(!test_convex) {n = 0}
   if(test_convex & n > 0){
 
-      #Convert results to dataframe
+    #Convert results to dataframe
     #Replicate
     d_convex_rep <- do.call("rbind", lapply(results_convex,
-                                          function(x) x$Replicates))
+                                            function(x) x$Replicates))
     row.names(d_convex_rep) <- NULL
     #Summary
     d_convex_sum <- do.call("rbind", lapply(results_convex, function(x) x$Summary))
@@ -280,133 +284,133 @@ calibration_glmnetmx <- function(data, #Data in **CLASS??** format
       } }
     ####Results non-convex####
     results <- foreach::foreach(x = 1:n, .options.snow = opts,
-   .export = to_export) %dopar% {
-     #Get grid x
-     grid_x <- formula_grid2[x,] #Get i candidate model
-     formula_x <- as.formula(grid_x$Formulas) #Get formula from grid x
-     reg_x <- grid_x$regm #Get regularization multiplier from grid x
+                                .export = to_export) %dopar% {
+                                  #Get grid x
+                                  grid_x <- formula_grid2[x,] #Get i candidate model
+                                  formula_x <- as.formula(grid_x$Formulas) #Get formula from grid x
+                                  reg_x <- grid_x$regm #Get regularization multiplier from grid x
 
-     #Complete model with AIC
-     #Complete model with AIC
-     m_aic <- try(glmnet_mx(p = data$calibration_data$pr_bg,
-                            data = data$calibration_data,
-                            f = formula_x, regmult = reg_x, calculate_AIC = T),
-                  silent = TRUE)
+                                  #Complete model with AIC
+                                  #Complete model with AIC
+                                  m_aic <- try(glmnet_mx(p = data$calibration_data$pr_bg,
+                                                         data = data$calibration_data,
+                                                         f = formula_x, regmult = reg_x, calculate_AIC = T),
+                                               silent = TRUE)
 
-     if(any(class(m_aic) == "try-error")) {
-       npar <- NA
-       AICc <- NA
-       is_c <- NA
-       mods <- NA
-       class(mods) <- "try-error"
-     } else
-       {
+                                  if(any(class(m_aic) == "try-error")) {
+                                    npar <- NA
+                                    AICc <- NA
+                                    is_c <- NA
+                                    mods <- NA
+                                    class(mods) <- "try-error"
+                                  } else
+                                  {
 
-       #Get number of parameters
-       npar <- length(m_aic$betas)
+                                    #Get number of parameters
+                                    npar <- length(m_aic$betas)
 
-       #Calculate AIC from Warren
-       vals <- predict.glmnet_mx(m_aic,
-                                 data$calibration_data[data$calibration_data$pr_bg == 1,],
-                                 type = "exponential")
+                                    #Calculate AIC from Warren
+                                    vals <- predict.glmnet_mx(m_aic,
+                                                              data$calibration_data[data$calibration_data$pr_bg == 1,],
+                                                              type = "exponential")
 
-       AICc <- aic_ws(pred_occs = vals, ncoefs = npar)
+                                    AICc <- aic_ws(pred_occs = vals, ncoefs = npar)
 
-       #Check if model has convex curves
-       m_betas <- m_aic$betas
-       #Select only quadratic betas
-       q_betas <- m_betas[grepl("\\^2", names(m_betas))]
-       #Check if is convex
-       if(length(q_betas) == 0) {
-         is_c <- FALSE} else {
-  is_c <- any(q_betas > 0)
-         }
-       #Get background index (again, if necessary)
-       bgind <- which(data$calibration_data == 0)
-       mods <- try(lapply(1:length(data$kfolds), function(i) {
-         notrain <- -data$kfolds[[i]]
-         data_i <- data$calibration_data[notrain,]
-         #Run model
-         mod_i <- glmnet_mx(p = data_i$pr_bg, data = data_i,
-                            f = formula_x, regmult = reg_x,
-                            calculate_AIC = FALSE)
+                                    #Check if model has convex curves
+                                    m_betas <- m_aic$betas
+                                    #Select only quadratic betas
+                                    q_betas <- m_betas[grepl("\\^2", names(m_betas))]
+                                    #Check if is convex
+                                    if(length(q_betas) == 0) {
+                                      is_c <- FALSE} else {
+                                        is_c <- any(q_betas > 0)
+                                      }
+                                    #Get background index (again, if necessary)
+                                    bgind <- which(data$calibration_data == 0)
+                                    mods <- try(lapply(1:length(data$kfolds), function(i) {
+                                      notrain <- -data$kfolds[[i]]
+                                      data_i <- data$calibration_data[notrain,]
+                                      #Run model
+                                      mod_i <- glmnet_mx(p = data_i$pr_bg, data = data_i,
+                                                         f = formula_x, regmult = reg_x,
+                                                         calculate_AIC = FALSE)
 
-         #Predict model only to background
-         pred_i <- as.numeric(predict(object = mod_i,
-                                      newdata = data$calibration_data,
-                                      clamp = FALSE, type = "cloglog"))
+                                      #Predict model only to background
+                                      pred_i <- as.numeric(predict(object = mod_i,
+                                                                   newdata = data$calibration_data,
+                                                                   clamp = FALSE, type = "cloglog"))
 
-         # #Predict model to spatraster, only to check
-         # vars_r <- terra::rast("Models/Araucaria_angustifolia/PCA_variables.tiff")
-         # pred_r <- terra::predict(vars_r, mod_i, type = "cloglog", na.rm = TRUE)
-         # plot(pred_r)
+                                      # #Predict model to spatraster, only to check
+                                      # vars_r <- terra::rast("Models/Araucaria_angustifolia/PCA_variables.tiff")
+                                      # pred_r <- terra::predict(vars_r, mod_i, type = "cloglog", na.rm = TRUE)
+                                      # plot(pred_r)
 
-         #Extract suitability in train and test points
-         suit_val_cal <- pred_i[unique(c(notrain, -bgind))]
-         suit_val_eval <- pred_i[which(!-notrain %in% bgind)]
+                                      #Extract suitability in train and test points
+                                      suit_val_cal <- pred_i[unique(c(notrain, -bgind))]
+                                      suit_val_eval <- pred_i[which(!-notrain %in% bgind)]
 
-         ####Calculate omission rate following kuenm####
-         om_rate <- omrat(threshold = omrat_thr,
-                          pred_train = suit_val_cal,
-                          pred_test = suit_val_eval)
-         #Calculate pROC following enmpa
-         proc_i <- enmpa::proc_enm(test_prediction = suit_val_eval,
-                                   prediction = pred_i)
+                                      ####Calculate omission rate following kuenm####
+                                      om_rate <- omrat(threshold = omrat_thr,
+                                                       pred_train = suit_val_cal,
+                                                       pred_test = suit_val_eval)
+                                      #Calculate pROC following enmpa
+                                      proc_i <- enmpa::proc_enm(test_prediction = suit_val_eval,
+                                                                prediction = pred_i)
 
-         ####Save metrics in a dataframe
-         df_eval <- data.frame(Replicate = i, t(data.frame(om_rate)),
-                               proc_auc_ratio = proc_i$pROC_summary[1],
-                               proc_pval = proc_i$pROC_summary[2],
-                               AIC_nk = m_aic$AIC,
-                               AIC_ws = AICc,
-                               npar = npar,
-                               is_convex = is_c,
-                               row.names = NULL)
-         df_eval2 <- cbind(grid_x, df_eval)
-         return(df_eval2)
-       }), silent = TRUE)
-       names(mods) <- names(data$kfolds)
-       }
+                                      ####Save metrics in a dataframe
+                                      df_eval <- data.frame(Replicate = i, t(data.frame(om_rate)),
+                                                            proc_auc_ratio = proc_i$pROC_summary[1],
+                                                            proc_pval = proc_i$pROC_summary[2],
+                                                            AIC_nk = m_aic$AIC,
+                                                            AIC_ws = AICc,
+                                                            npar = npar,
+                                                            is_convex = is_c,
+                                                            row.names = NULL)
+                                      df_eval2 <- cbind(grid_x, df_eval)
+                                      return(df_eval2)
+                                    }), silent = TRUE)
+                                    names(mods) <- names(data$kfolds)
+                                  }
 
-     #####Create empty dataframe if mods is an error####
-     if(class(mods) == "try-error") {
-       eval_final <- cbind(grid_x, empty_replicates(omrat_thr = omrat_thr,
-     n_row = length(data$kfolds),
-     replicates = names(data$kfolds), is_c = is_c))
-     } else{
-       #Return evaluation final
-       eval_final <- do.call("rbind", mods) }
+                                  #####Create empty dataframe if mods is an error####
+                                  if(class(mods) == "try-error") {
+                                    eval_final <- cbind(grid_x, empty_replicates(omrat_thr = omrat_thr,
+                                                                                 n_row = length(data$kfolds),
+                                                                                 replicates = names(data$kfolds), is_c = is_c))
+                                  } else{
+                                    #Return evaluation final
+                                    eval_final <- do.call("rbind", mods) }
 
-     #Summarize results
-     if(class(mods) == "try-error") {
-         eval_final <- cbind(grid_x,
-           empty_summary(omrat_thr = omrat_thr, is_c = is_c))
-       } else {
-         eval_final_summary <- eval_stats(eval_final) }
-
-
-     #If write_summary = T...
-     if(write_summary){
-       write.csv(eval_final_summary, file.path(out_dir,
- paste0("Summary_cand_model_", grid_x$ID, ".csv")),
-        row.names = F)
-     }
+                                  #Summarize results
+                                  if(class(mods) == "try-error") {
+                                    eval_final_summary <- cbind(grid_x,
+                                                        empty_summary(omrat_thr = omrat_thr, is_c = is_c))
+                                  } else {
+                                    eval_final_summary <- eval_stats(eval_final) }
 
 
-     if(!return_replicate)
-       eval_final <- NULL
+                                  #If write_summary = T...
+                                  if(write_summary){
+                                    write.csv(eval_final_summary, file.path(out_dir,
+                                                                            paste0("Summary_cand_model_", grid_x$ID, ".csv")),
+                                              row.names = F)
+                                  }
 
-     return(list(All_results = eval_final,
-                 Summary = eval_final_summary)) } #End of foreach
+
+                                  if(!return_replicate)
+                                    eval_final <- NULL
+
+                                  return(list(All_results = eval_final,
+                                              Summary = eval_final_summary)) } #End of foreach
 
     #Stop cluster
     parallel::stopCluster(cl)
 
     #Convert to dataframe
-      #Replicate
+    #Replicate
     d_res_rep <- do.call("rbind", lapply(results, function(x) x$Replicates))
     row.names(d_res_rep) <- NULL
-      #Summary
+    #Summary
     d_res_sum <- do.call("rbind", lapply(results, function(x) x$Summary))
 
     # Join results with results convex, if it exists
@@ -426,17 +430,17 @@ calibration_glmnetmx <- function(data, #Data in **CLASS??** format
   bm <- sel_best_models(cand_models = res_final$Summary, #dataframe with Candidate results
                         test_convex = test_convex, #Remove models with concave curves?
                         omrat_threshold = omrat_threshold, #Omission rate (test points) used to select the best models
-                        allow_tolerance = T, #If omission rate is higher than set, select the model with minimum omission rate
-                        tolerance = 0.01, #If allow tollerance, select the model with minimum omission rate + tolerance
-                        AIC = "nk", #Which AIC? japones (nk) or Warrien (ws?
+                        allow_tolerance = allow_tolerance, #If omission rate is higher than set, select the model with minimum omission rate
+                        tolerance = tolerance, #If allow tollerance, select the model with minimum omission rate + tolerance
+                        AIC = AIC, #Which AIC? japones (nk) or Warrien (ws?
                         significance = 0.05, #Significante to select models based on pROC
                         verbose = verbose, #Show messages?
-                        delta_aic = 2, #Delta AIC to select best models
+                        delta_aic = delta_aic, #Delta AIC to select best models
                         save_file = F, #Save file with best models?
                         file_name = NULL)
   #Concatenate final results
   return(c(data, calibration_results = list(res_final),
-             selected_models = list(bm)))
+           selected_models = list(bm)))
 
 } #End of function
 

--- a/R/evaluation_functions.R
+++ b/R/evaluation_functions.R
@@ -39,6 +39,8 @@ aic_nk <- function(x, y, beta) {
 
   pr0 <- 1 - 1 / (1 + exp(predict_glm))
   pr <- 1 - 1 / (1 + exp(cbind(1, x) %*% beta))
+  #.Machine$double.eps added to deal with pr = 0
+  pr <- pr + .Machine$double.eps
   cc <- as.vector(beta)
   jc <- abs(cc) > 1e-05
   xj <- cbind(1, x)[, jc]

--- a/R/glmnet_mx.R
+++ b/R/glmnet_mx.R
@@ -59,6 +59,8 @@ glmnet_mx <- function(p, data, f, regmult = 1.0,
   model$alpha <- 0
   rr <- predict.glmnet_mx(model, data[p == 0, , drop = FALSE],
                           type = "exponent", clamp = FALSE)
+  #.Machine$double.eps added to deal with rr = 0
+  rr <- rr + .Machine$double.eps
   raw <- rr / sum(rr)
   model$entropy <- -sum(raw * log(raw))
   model$alpha <- -log(sum(rr))

--- a/R/part_data.R
+++ b/R/part_data.R
@@ -49,10 +49,8 @@ part_data <- function(data,
 return(rep_data)
 } #End of function
 
-
-
-# #Test function
-data <- read.csv("Models/Piper_fuligineum/occ_bg.csv")
-a <- part_data(data = data, train_portion = 0.75,
-               n_replicates = 5,
-               method = "subsample")
+# # #Test function
+# data <- read.csv("Models/Piper_fuligineum/occ_bg.csv")
+# a <- part_data(data = data, train_portion = 0.75,
+#                n_replicates = 5,
+#                method = "subsample")

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -1,15 +1,15 @@
 #### Prepare SWD ####
-library(terra)
-occ <- read.csv("Models/Myrcia_hatschbachii/Occurrences.csv")
-species <- "Myrcia_hatschbachii"
-x = "x"
-y = "y"
-spat_variables <- rast("Models/Myrcia_hatschbachii/PCA_var.tiff")
-nbg = 10000
-kfolds = 4
-include_xy = TRUE
-writeFiles = F
-out_dir = NULL
+# library(terra)
+# occ <- read.csv("Models/Myrcia_hatschbachii/Occurrences.csv")
+# species <- "Myrcia_hatschbachii"
+# x = "x"
+# y = "y"
+# spat_variables <- rast("Models/Myrcia_hatschbachii/PCA_var.tiff")
+# nbg = 10000
+# kfolds = 4
+# include_xy = TRUE
+# writeFiles = F
+# out_dir = NULL
 
 #library(terra)
 prepare_data <- function(occ,
@@ -93,20 +93,20 @@ prepare_data <- function(occ,
   return(data)
 }
 
-# #Test
-tt <- prepare_data(occ = occ,
-                   species = "species",
-                   x = "x",
-                   y = "y",
-                   spat_variables = rast("Models/Myrcia_hatschbachii/PCA_var.tiff"),
-                   categorical_variables = "SoilType",
-                   nbg = 10000,
-                   kfolds = 4,
-                   include_xy = TRUE,
-                   write_files = T,
-                   file_name =  "Models/Myrcia_hatschbachii/Data")
-
-tt2 <- readRDS("Models/Myrcia_hatschbachii/Data.RDS")
-tt2$calibration_data %>% str()
-
-any(is.na(tt2$calibration_data))
+# # #Test
+# tt <- prepare_data(occ = occ,
+#                    species = "species",
+#                    x = "x",
+#                    y = "y",
+#                    spat_variables = rast("Models/Myrcia_hatschbachii/PCA_var.tiff"),
+#                    categorical_variables = "SoilType",
+#                    nbg = 10000,
+#                    kfolds = 4,
+#                    include_xy = TRUE,
+#                    write_files = T,
+#                    file_name =  "Models/Myrcia_hatschbachii/Data")
+#
+# tt2 <- readRDS("Models/Myrcia_hatschbachii/Data.RDS")
+# tt2$calibration_data %>% str()
+#
+# any(is.na(tt2$calibration_data))


### PR DESCRIPTION
Enhance calibration_glmnetx function to incorporate tolerance for cases where the chosen omission rate threshold is lower than the minimum calculated omission rate.
Resolve bug in calibration_glmnetx function associated with returning eval_final_summary when the model encounters a try=error.
In evaluation_functions, sum .Machine$double.eps to predictions, enabling the calculation of AIC when predictions equal 0.
For glmnet_mx, sum .Machine$double.eps to predictions, enabling the calculation of entropy when predictions equal 0.
Commented out the tests examples in part_data and prepare_data.
