### PR TITLE
Adjust parallelization according to the number of models and replicates

### DIFF
--- a/R/fit_selected_glmnetmx.R
+++ b/R/fit_selected_glmnetmx.R
@@ -98,6 +98,14 @@ fit_selected_glmnetmx <- function(calibration_results,
     pb <- txtProgressBar(0, n_tot, style = 3)
     progress <- function(n) setTxtProgressBar(pb, n) }
 
+  #Adjust parallelization according to the number of cores
+  if(n_tot == 1 & isTRUE(parallel)){
+    parallel <- FALSE
+  }
+  if(n_tot < ncores & isTRUE(parallel)){
+    ncores <- n_tot
+  }
+
   #Set parallelization
   if(parallel) {
     #Make cluster


### PR DESCRIPTION
When parallel is set to TRUE, but only one model needs to be fitted, parallel is set to FALSE.
When the number of cores exceeds the number of models to be fitted, the number of cores is adjusted to match the number of models