### PR TITLE
Fix bug when extracting variable names from models

### DIFF
--- a/R/helpers_project_selected_glmnetx.R
+++ b/R/helpers_project_selected_glmnetx.R
@@ -66,6 +66,19 @@ multiple_projections <- function(i, res_path, raster_pattern, par_list){
   #Import rasters
   r_i <- terra::rast(list.files(input_i, full.names = T,
                                 pattern = raster_pattern))
+  ####PCA ?##########
+  #If pca is not NULL, predict pca
+  if(!is.null(par_list$models$pca)){
+    vars_in_pca <- names(par_list$models$pca$center)
+    vars_out_pca <- setdiff(names(r_i), vars_in_pca)
+    r_i_pca <- terra::predict(r_i[[vars_in_pca]], par_list$models$pca)
+    if(length(vars_out_pca) == 0) {
+      r_i <- r_i_pca} else {
+        r_i <- c(r_i_pca, r_i[[ vars_out_pca]])
+      }
+  }
+  ##################
+
   #Predict
   invisible(predict_selected_glmnetmx(models = par_list$models,
                                       spat_var = r_i,

--- a/R/predict_selected_glmnetmx.R
+++ b/R/predict_selected_glmnetmx.R
@@ -45,7 +45,7 @@ predict_selected_glmnetmx <- function(models,
     varmax <- models[[1]][[1]]$varmax[-1] #Get var min
     #Variables to clamp (all variables if var_to_clamp = NULL)
     if(is.null(var_to_clamp)) {
-      var_to_clamp <- names(varmin)
+      var_to_clamp <- setdiff(names(varmin), c("pr_bg", "fold"))
     }
 
     #Clamp variables

--- a/R/prepare_proj.R
+++ b/R/prepare_proj.R
@@ -37,18 +37,16 @@ prepare_proj <- function(models = NULL,
       stop(paste("present_dir", present_dir, "does not exist"))
     }
 
-    #List internal directories
+    #List internal directories or files
     internal_dir <- list.dirs(present_dir, recursive = T)[-1]
 
-    if(length(internal_dir) == 0) {
-      stop(paste("present_dir", present_dir, "is empty"))
-    }
+    #Check if there is a file in the directory
+    fdir <- list.files(present_dir, pattern = raster_pattern)
 
     #Check if there are several scenarios
     pdir <- list.dirs(present_dir)[-1]
-    #Check if there is a file in the directory
-    fdir <- list.files(present_dir, pattern = raster_pattern)
-    if(length(pdir) == 0 & length(fdir) == 0) {
+
+    if(length(pdir) == 0 & length(fdir) == 0 & length(internal_dir) == 0) {
       stop("present_dir ", present_dir, " has no folders or files to project")
     }
 
@@ -62,7 +60,7 @@ prepare_proj <- function(models = NULL,
              paste(abs_vars, collapse = "\n"))
       #If everything is OK, create list with the path
       res_present <- list()
-      res_present[["Present"]] <- present_dir
+      res_present[["Present"]] <- normalizePath(present_dir)
     }
 
     #To project using folders

--- a/R/project_selected_glmnetx.R
+++ b/R/project_selected_glmnetx.R
@@ -38,7 +38,8 @@ project_selected_glmnetx <- function(models,
 
   ####PREPARE DATAFRAME TO PREDICT####
   #Extract variables from best models
-  vars <- names(models[["Models"]][[1]][[1]]$samplemeans)[-1]
+  vars <- names(models[["Models"]][[1]][[1]]$samplemeans)
+  vars <- setdiff(vars, c("pr_bg", "fold"))
 
   if(!file.exists(out_dir)){
     dir.create(out_dir, showWarnings = FALSE)
@@ -180,13 +181,13 @@ project_selected_glmnetx <- function(models,
             ,
             .export = c("predict_selected_glmnetmx")
     ) %dopar% {
-      kuenm2:::multiple_projections(i = x, res_path, raster_pattern, par_list)
+      multiple_projections(i = x, res_path, raster_pattern, par_list)
     }
   } else { #Not in parallel (using %do%)
     # Loop for com barra de progresso manual
     for (x in 1:n_models) {
       # Execute a função fit_eval_models
-      kuenm2:::multiple_projections(i = x, res_path, raster_pattern, par_list)
+      multiple_projections(i = x, res_path, raster_pattern, par_list)
 
       # Sets the progress bar to the current state
       if(progress_bar){


### PR DESCRIPTION
Fix bug when extracting variable names from models
Fix bug when there is only one single tif file in present
Test - adding option to predict pca-variables before predict when prcomp object is available