### PR TITLE
RAM overload, unnecessary objects, and PCA variables

### DIFF
--- a/R/evaluation_functions.R
+++ b/R/evaluation_functions.R
@@ -1,5 +1,5 @@
 ####Omission Rate####
-omrat <- function(threshold = 5, pred_train, pred_test) {
+omrat <- function(threshold, pred_train, pred_test) {
   om_rate <- vector("numeric", length = length(threshold))
   for (i in 1:length(threshold)) {
     val <- ceiling(length(pred_train) * threshold[i] / 100) + 1

--- a/R/fit_selected_glmnetmx.R
+++ b/R/fit_selected_glmnetmx.R
@@ -91,17 +91,20 @@ fit_selected_glmnetmx <- function(calibration_results,
                            # ,
                            #     .export = c(to_export)
     ) %dopar% {
-      kuenm2:::fit_best_model(x = x, dfgrid, calibration_results, data_x, n_replicates,
-                     rep_data)
+      fit_best_model(x = x, dfgrid = dfgrid,
+                     calibration_results = calibration_results,
+                     n_replicates = n_replicates,
+                     rep_data = rep_data)
     }
   } else { #Not in parallel (using %do%)
     best_models <- vector("list", length = n_tot)
     # Loop for com barra de progresso manual
     for (x in 1:n_tot) {
       # Execute a função fit_eval_models
-      best_models[[x]] <- kuenm2:::fit_best_model(x = x, dfgrid, calibration_results,
-                                         data_x, n_replicates,
-                                         rep_data)
+      best_models[[x]] <- fit_best_model(x = x, dfgrid = dfgrid,
+                                         calibration_results = calibration_results,
+                                         n_replicates = n_replicates,
+                                         rep_data = rep_data)
 
       # Sets the progress bar to the current state
       if(progress_bar){
@@ -254,6 +257,7 @@ fit_selected_glmnetmx <- function(calibration_results,
               calibration_data = calibration_results$calibration_data,
               selected_models = calibration_results$selected_models,
               weights = calibration_results$weights,
+              pca = calibration_results$pca,
               addsamplestobackground = calibration_results$addsamplestobackground,
               omission_rate = calibration_results$omission_rate,
               thresholds = p_thr)

--- a/R/glmnet_mx.R
+++ b/R/glmnet_mx.R
@@ -10,7 +10,8 @@ glmnet_mx <- function(p, data, f, regmult = 1.0,
                       regfun = maxnet.default.regularization,
                       addsamplestobackground = TRUE,
                       weights = NULL,
-                      calculate_AIC = FALSE, ...) {
+                      calculate_AIC = FALSE, AIC = "ws",
+                      ...) {
   if (anyNA(data)) {
     stop("NA values in data table. Please remove them and rerun.")
   }
@@ -68,7 +69,7 @@ glmnet_mx <- function(p, data, f, regmult = 1.0,
   filter <- bb[-1] != 0
   bb <- c(bb[1], bb[-1][filter])
 
-  if (calculate_AIC & sum(filter) != 0) {
+  if (calculate_AIC & sum(filter) != 0 & AIC == "nk") {
     model$AIC <- aic_nk(x = as.matrix(mm[, filter]), y = p, beta = bb)
   } else {
     model$AIC <- NA

--- a/R/helpers_project_selected_glmnetx.R
+++ b/R/helpers_project_selected_glmnetx.R
@@ -66,22 +66,23 @@ multiple_projections <- function(i, res_path, raster_pattern, par_list){
   #Import rasters
   r_i <- terra::rast(list.files(input_i, full.names = T,
                                 pattern = raster_pattern))
-  ####PCA ?##########
-  #If pca is not NULL, predict pca
-  if(!is.null(par_list$models$pca)){
-    vars_in_pca <- names(par_list$models$pca$center)
-    vars_out_pca <- setdiff(names(r_i), vars_in_pca)
-    r_i_pca <- terra::predict(r_i[[vars_in_pca]], par_list$models$pca)
-    if(length(vars_out_pca) == 0) {
-      r_i <- r_i_pca} else {
-        r_i <- c(r_i_pca, r_i[[ vars_out_pca]])
-      }
-  }
-  ##################
+  # ####PCA ?##########
+  # #If pca is not NULL, predict pca
+  # if(!is.null(par_list$models$pca)){
+  #   vars_in_pca <- names(par_list$models$pca$center)
+  #   vars_out_pca <- setdiff(names(r_i), vars_in_pca)
+  #   r_i_pca <- terra::predict(r_i[[vars_in_pca]], par_list$models$pca)
+  #   if(length(vars_out_pca) == 0) {
+  #     r_i <- r_i_pca} else {
+  #       r_i <- c(r_i_pca, r_i[[ vars_out_pca]])
+  #     }
+  # }
+  # ##################
 
   #Predict
   invisible(predict_selected_glmnetmx(models = par_list$models,
                                       spat_var = r_i,
+                                      do_pca = par_list$projection_file$do_pca,
                                       write_replicates = par_list$write_replicates,
                                       out_dir = output_i,
                                       consensus_per_model = par_list$consensus_per_model,

--- a/R/predict_selected_glmnetmx.R
+++ b/R/predict_selected_glmnetmx.R
@@ -5,6 +5,7 @@
 
 predict_selected_glmnetmx <- function(models,
                            spat_var,
+                           do_pca = FALSE,
                            write_files = FALSE,
                            write_replicates = FALSE,
                            out_dir = NULL,
@@ -17,6 +18,16 @@ predict_selected_glmnetmx <- function(models,
                            overwrite = FALSE,
                            progress_bar = TRUE) {
 
+
+  #Do PCA, if necessary
+  if(do_pca){
+    var_pca <- terra::predict(spat_var[[models$pca$vars_in]], models$pca)
+    if(!("vars_out" %in% names(models$pca))) {
+      spat_var <- var_pca} else {
+        spat_var <- c(var_pca, spat_var[[models$pca$vars_out]])
+        rm(var_pca)
+      }
+  }
 
   #Get models names
   models <- models[["Models"]]

--- a/R/prepare_proj.R
+++ b/R/prepare_proj.R
@@ -4,6 +4,7 @@
 
 prepare_proj <- function(models = NULL,
                          variable_names = NULL,
+                         do_pca = FALSE,
                          present_dir = NULL,
                          past_dir = NULL, past_period = NULL, past_gcm = NULL,
                          future_dir = NULL, future_period = NULL,
@@ -12,18 +13,28 @@ prepare_proj <- function(models = NULL,
                          filename = NULL,
                          raster_pattern = ".tif*") {
 
+  if(is.null(models) & is.null(variable_names)) {
+    stop("You must specify models or variable_names")
+  }
+
   #Extract variables from best models
   if(!is.null(models)){
-  models <- models[["Models"]]
-  vars <- names(models[[1]][[1]]$samplemeans)[-1]
+    #If do pca, check if variables to run pca are available
+    if(do_pca){
+      if("vars_out" %in% names(models$pca)){
+        vars <- c(models$pca$vars_in, models$pca$vars_out)
+      } else {
+        vars <- models$pca$vars_in
+      }
+
+    } else {
+      #If do not use pca
+  models[["Models"]]
+  vars <- names(models[["Models"]][[1]][[1]]$samplemeans)[-1]}
   }
 
   if(is.null(models) & !is.null(variable_names)){
     vars <- variable_names
-  }
-
-  if(is.null(models) & is.null(variable_names)) {
-    stop("You must specify models or variable_names")
   }
 
   if(!is.null(models) & !is.null(variable_names)) {
@@ -226,6 +237,9 @@ prepare_proj <- function(models = NULL,
 
   #Append raster pattern
   res[["Raster_pattern"]] <- raster_pattern
+
+  #Append do PCA
+  res[["do_pca"]] <- do_pca
 
   #Save results as RDS
   if(write_file){

--- a/R/sel_best_models.R
+++ b/R/sel_best_models.R
@@ -15,12 +15,14 @@ sel_best_models <- function(cand_models,
                      save_file = T,
                      file_name = NULL){
 
+  #Remove column with the other AIC
   if(AIC == "nk") {
-    AIC <- "AIC_nk"}
+    AIC <- "AIC_nk"
+    cand_models$AIC_ws <- NULL}
 
   if(AIC == "ws") {
-    AIC <- "AIC_ws"}
-
+    AIC <- "AIC_ws"
+    cand_models$AIC_nk <- NULL}
 
   #Which omission rate?
   om_thr <- paste0("Omission_rate_at_", omrat_threshold, ".mean")


### PR DESCRIPTION
NEWS:

- calibration_glmnetmx: remove the unnecessary object formulagrid2
- calibration_grid_glmnetmx: simplify the function by using a for loop instead of lapply
- omrat: remove the default value of the threshold argument.
- glmnet_mx and sel_best_models: Calculate and use nk AIC only when AIC is 'nk' to avoid overloading RAM.
- helpers_project_selected_glmnetx, predict_selected_glmnetmx, prepare_data and prepare_proj: Modify the functions to work with PCA variables using raw variables without writing PCA variables.