### PR TITLE
var_limits and averages_from

### DIFF
--- a/R/helpers_prepare_data.R
+++ b/R/helpers_prepare_data.R
@@ -166,7 +166,7 @@ calibration_grid_glmnetmx <- function(occ_bg,
   # Remove combinations according to minimum number of continuous variables
   if(!is.null(min_continuous) & !is.null(categorical_var)){
     n_cont <- sapply(var_comb, function(x) length(x[x != categorical_var]))
-    var_comb <- var_comb[n_cont > min_continuous]
+    var_comb <- var_comb[n_cont >= min_continuous]
   }
 
   # Split features

--- a/man/calibration2.Rd
+++ b/man/calibration2.Rd
@@ -5,7 +5,8 @@
 \title{Calibration, evaluation, and selection of candidate models}
 \usage{
 calibration2(data, test_concave = TRUE, extrapolation_factor = 0.1,
-           limit_is_zero = NULL, addsamplestobackground = TRUE,
+           var_limits = NULL, averages_from = "pr" ,
+           addsamplestobackground = TRUE,
            use_weights = FALSE, parallel = TRUE, ncores = 4,
            parallel_type = "doSNOW", progress_bar = TRUE, write_summary = FALSE,
            out_dir = NULL, skip_existing_models = FALSE,
@@ -26,11 +27,16 @@ extrapolation range for each variable when detecting concave curves. Larger
 values allow broader extrapolation beyond the observed data range, while
 smaller values restrict the range. Default is 0.1. See details.}
 
-\item{limit_is_zero}{(character) names of variables whose lower limit is zero
-and should not include negative values (e.g., precipitation variables). This
-ensures that the detection of concave curves, which identify higher
-suitability at both extremes, are constrained at the lower boundary of zero.
-Default is NULL, meaning no variables will have their lower limit set to zero.}
+\item{var_limits}{(list) A named list specifying the lower and/or upper limits
+for some variables. The first value represents the lower limit, and the
+second value represents the upper limit. Default is \code{NULL}, meaning no
+specific limits are applied, and the range will be calculated using the
+\code{extrapolation_factor}. See details.}
+
+\item{averages_from}{(character) specifies how the averages or modes of the
+variables are calculated. Available options are "pr" (to calculate averages
+from the presence localities) or "pr_bg" (to use the combined set of presence
+and background localities). Default is "pr". See details.}
 
 \item{addsamplestobackground}{(logical) whether to add to the background any
 presence sample that is not already there. Default is TRUE.}
@@ -150,6 +156,18 @@ as the difference between the variable's maximum and minimum values in the
 model, multiplied by the extrapolation factor. A concave curve is detected
 when the beta coefficient is positive, and the vertex — where the curve
 changes direction — lies between the lower and upper limits of the variable.
+
+Users can specify the lower and upper limits for certain variables using
+\code{var_limits}. For example, if \code{var_limits = list("bio12" = c(0, NA),
+"bio15" = c(0, 100))}, the lower limit for \code{bio12} will be 0, and the
+upper limit will be calculated using the extrapolation factor. Similarly,
+the lower and upper limits for \code{bio15} will be 0 and 100, respectively.
+
+For calculating the vertex position, a response curve for a given variable is
+generated with all other variables set to their mean values (or mode for
+categorical variables). These values are calculated either from the presence
+localities (if \code{averages_from = "pr"}) or from the combined set of
+presence and background localities (if \code{averages_from = "pr_bg"}).
 }
 \examples{
 # Import occurrences
@@ -158,9 +176,8 @@ data(occ_data, package = "kuenm2")
 # Import variables
 var <- terra::rast(system.file("extdata", "Current_variables.tif",
                                package = "kuenm2"))
-
-# Use only variables 1, 2 and 3
-var <- var[[1:3]]
+#Remove categorical variable
+var <- var[[1:4]]
 
 #### GLMNET ####
 # Prepare data for glmnet model
@@ -171,7 +188,7 @@ sp_swd <- prepare_data(model_type = "glmnet", occ = occ_data,
                        do_pca = FALSE, deviance_explained = 95,
                        min_explained = 5, center = TRUE, scale = TRUE,
                        write_pca = FALSE, output_pca = NULL, nbg = 100,
-                       kfolds = 4, weights = NULL, min_number = 2,
+                       kfolds = 4, weights = NULL, min_number = 3,
                        min_continuous = NULL,
                        features = c("l", "lq"),
                        regm = 1,
@@ -181,24 +198,27 @@ sp_swd <- prepare_data(model_type = "glmnet", occ = occ_data,
 
 # Calibrate glmnet models
 m <- calibration2(data = sp_swd,
-                 test_concave = TRUE,
-                 extrapolation_factor = 0.1,
-                 limit_is_zero = NULL,
-                 parallel = FALSE,
-                 ncores = 1,
-                 progress_bar = TRUE,
-                 write_summary = FALSE,
-                 out_dir = NULL,
-                 parallel_type = "doSNOW",
-                 return_replicate = TRUE,
-                 omission_rate = c(5, 10),
-                 omrat_threshold = 10,
-                 allow_tolerance = TRUE,
-                 tolerance = 0.01,
-                 AIC = "ws",
-                 delta_aic = 2,
-                 skip_existing_models = FALSE,
-                 verbose = TRUE)
+                  test_concave = TRUE,
+                  extrapolation_factor = 0.1,
+                  var_limits = list("bio_7" = c(0, NA),
+                                    "bio_12" = c(0, NA),
+                                    "bio_15" = c(0, 100)),
+                  averages_from = "pr",
+                  parallel = FALSE,
+                  ncores = 1,
+                  progress_bar = TRUE,
+                  write_summary = FALSE,
+                  out_dir = NULL,
+                  parallel_type = "doSNOW",
+                  return_replicate = TRUE,
+                  omission_rate = c(5, 10),
+                  omrat_threshold = 10,
+                  allow_tolerance = TRUE,
+                  tolerance = 0.01,
+                  AIC = "ws",
+                  delta_aic = 2,
+                  skip_existing_models = FALSE,
+                  verbose = TRUE)
 m
 
 #### GLM ####
@@ -210,7 +230,7 @@ sp_swd_glm <- prepare_data(model_type = "glm", occ = occ_data,
                            do_pca = FALSE, deviance_explained = 95,
                            min_explained = 5, center = TRUE, scale = TRUE,
                            write_pca = FALSE, output_pca = NULL, nbg = 100,
-                           kfolds = 4, weights = NULL, min_number = 2,
+                           kfolds = 4, weights = NULL, min_number = 3,
                            min_continuous = NULL,
                            features = c("l", "lq"),
                            regm = 1,
@@ -220,25 +240,29 @@ sp_swd_glm <- prepare_data(model_type = "glm", occ = occ_data,
 
 # Calibrate glm models
 m_glm <- calibration2(data = sp_swd_glm,
-                     test_concave = TRUE,
-                     extrapolation_factor = 0.1,
-                     limit_is_zero = NULL,
-                     parallel = FALSE,
-                     ncores = 1,
-                     progress_bar = TRUE,
-                     write_summary = FALSE,
-                     out_dir = NULL,
-                     parallel_type = "doSNOW",
-                     return_replicate = TRUE,
-                     omission_rate = c(5, 10),
-                     omrat_threshold = 10,
-                     allow_tolerance = TRUE,
-                     tolerance = 0.01,
-                     AIC = "ws",
-                     delta_aic = 2,
-                     skip_existing_models = FALSE,
-                     verbose = TRUE)
+                      test_concave = TRUE,
+                      extrapolation_factor = 0.1,
+                      var_limits = list("bio_7" = c(0, NA),
+                                        "bio_12" = c(0, NA),
+                                        "bio_15" = c(0, 100)),
+                      averages_from = "pr",
+                      parallel = FALSE,
+                      ncores = 1,
+                      progress_bar = TRUE,
+                      write_summary = FALSE,
+                      out_dir = NULL,
+                      parallel_type = "doSNOW",
+                      return_replicate = TRUE,
+                      omission_rate = c(5, 10),
+                      omrat_threshold = 10,
+                      allow_tolerance = TRUE,
+                      tolerance = 0.01,
+                      AIC = "ws",
+                      delta_aic = 2,
+                      skip_existing_models = FALSE,
+                      verbose = TRUE)
 m_glm
+
 }
 \references{
 Ninomiya, Yoshiyuki, and Shuichi Kawano. "AIC for the Lasso in generalized

--- a/man/detect_concave.Rd
+++ b/man/detect_concave.Rd
@@ -5,7 +5,7 @@
 \title{Detect concave curves in GLM and GLMNET models}
 \usage{
 detect_concave(model, calib_data, extrapolation_factor = 0.1,
-                     limit_is_zero = NULL, plot = FALSE,
+                     var_limits = NULL, averages_from, plot = FALSE,
                      mfrow = NULL, legend = FALSE)
 }
 \arguments{
@@ -17,11 +17,16 @@ detect_concave(model, calib_data, extrapolation_factor = 0.1,
 extrapolation range. Larger values allow broader extrapolation beyond the
 observed data range. Default is 0.1.}
 
-\item{limit_is_zero}{(character) names of variables whose lower limit is zero
-and should not include negative values (e.g., precipitation variables). This
-ensures that the detection of concave curves, which identify higher
-suitability at both extremes, are constrained at the lower boundary of zero.
-Default is NULL, meaning no variables will have their lower limit set to zero.}
+\item{averages_from}{(character) specifies how the averages or modes of the
+variables are calculated. Available options are "pr" (to calculate averages
+from the presence localities) or "pr_bg" (to use the combined set of presence
+and background localities). Default is "pr". See details.}
+
+\item{var_limits}{(list) A named list specifying the lower and/or upper limits
+for some variables. The first value represents the lower limit, and the
+second value represents the upper limit. Default is \code{NULL}, meaning no
+specific limits are applied, and the range will be calculated using the
+\code{extrapolation_factor}. See details.}
 
 \item{plot}{(logical) whether to plot the response curve for the variables.
 Default is FALSE.}
@@ -61,6 +66,18 @@ as the difference between the variable's maximum and minimum values in the
 model, multiplied by the extrapolation factor. A concave curve is detected
 when the beta coefficient is positive, and the vertex — where the curve
 changes direction — lies between the lower and upper limits of the variable.
+
+Users can specify the lower and upper limits for certain variables using
+\code{var_limits}. For example, if \code{var_limits = list("bio12" = c(0, NA),
+"bio15" = c(0, 100))}, the lower limit for \code{bio12} will be 0, and the
+upper limit will be calculated using the extrapolation factor. Similarly,
+the lower and upper limits for \code{bio15} will be 0 and 100, respectively.
+
+For calculating the vertex position, a response curve for a given variable is
+generated with all other variables set to their mean values (or mode for
+categorical variables). These values are calculated either from the presence
+localities (if \code{averages_from = "pr"}) or from the combined set of
+presence and background localities (if \code{averages_from = "pr_bg"}).
 }
 \examples{
 # Import example of a fitted_model (output of fit_selected()) that have

--- a/man/response_curve.Rd
+++ b/man/response_curve.Rd
@@ -6,7 +6,9 @@
 \usage{
 response_curve(models, variable, modelID = NULL, n = 100,
                      by_replicates = FALSE, data = NULL, new_data = NULL,
+                     averages_from = "pr",
                      extrapolate = TRUE, extrapolation_factor = 0.1,
+                     l_limit = NULL, u_limit = NULL,
                      xlab = NULL, ylab = "Suitability",
                      col = "darkblue", ...)
 }
@@ -32,6 +34,11 @@ representing the range of variable values in an area of interest.
 Default = NULL. It must be defined in case the model entered does not
 explicitly include a data component.}
 
+\item{averages_from}{(character) specifies how the averages or modes of the
+variables are calculated. Available options are "pr" (to calculate averages
+from the presence localities) or "pr_bg" (to use the combined set of presence
+and background localities). Default is "pr". See details.}
+
 \item{extrapolate}{(logical) whether to allow extrapolation to study the
 behavior of the response outside the calibration limits. Ignored if
 \code{new_data} is defined. Default = TRUE.}
@@ -39,6 +46,16 @@ behavior of the response outside the calibration limits. Ignored if
 \item{extrapolation_factor}{(numeric) a multiplier used to calculate the
 extrapolation range. Larger values allow broader extrapolation beyond the
 observed data range. Default is 0.1.}
+
+\item{l_limit}{(numeric) specifies the lower limit for the variable. Default
+is \code{NULL}, meaning the lower limit will be calculated based on the
+data's minimum value and the \code{extrapolation_factor}
+(if \code{extrapolation = TRUE}).}
+
+\item{u_limit}{(numeric) specifies the upper limit for the variable. Default
+is \code{NULL}, meaning the upper limit will be calculated based on the
+data's minimum value and the \code{extrapolation_factor}
+(if \code{extrapolation = TRUE}).}
 
 \item{xlab}{(character) a label for the x axis. The default, NULL, uses the
 name defined in \code{variable}.}
@@ -55,6 +72,12 @@ A plot with the response curve for a \code{variable}.
 \description{
 A view of variable responses in fitted models. Responses based on single or multiple
 models can be provided.
+}
+\details{
+The response curves are generated with all other variables set to their mean
+values (or mode for categorical variables), calculated either from the
+presence localities (if averages_from = "pr") or from the combined set of
+presence and background localities (if averages_from = "pr_bg").
 }
 \examples{
 ##Example with glmnet


### PR DESCRIPTION
- In calibration2 and detect_concave, added the arguments var_limits (to specify lower and upper limits) and averages_from (to indicate whether averages are calculated from presence-only data or presence and background data).
- In response_curves, added the argument averages_from. Also added l_limit and u_limit to allow manual specification of lower and upper limits.